### PR TITLE
fix socket receive error on disconnect

### DIFF
--- a/source/kaleidic/mongo_standalone.d
+++ b/source/kaleidic/mongo_standalone.d
@@ -461,7 +461,9 @@ class ReceiveStream {
 			bufferLength = 0;
 		}
 		auto ret = socket.receive(buffer[bufferLength .. $]);
-		if(ret <= 0)
+		if (ret == 0)
+			throw new Exception("Remote side has closed the connection");
+		else if (ret == Socket.ERROR)
 			throw new Exception(lastSocketError());
 		bufferLength += ret;
 	}


### PR DESCRIPTION
Before if the connection was closed, lastSocketError() would have returned some string like "success", making a confusing error message