### PR TITLE
Fix SendBuffer internal buffer re-allocation

### DIFF
--- a/source/kaleidic/mongo_standalone.d
+++ b/source/kaleidic/mongo_standalone.d
@@ -887,10 +887,9 @@ struct SendBuffer {
 	private void size(size_t addition) {
 		if(buffer is null)
 			buffer = backing[];
-		if(position + addition > buffer.length) {
-                        buffer.length = buffer.length * 2;
-                        size(addition);
-                }
+		while (position + addition > buffer.length) {
+			buffer.length = buffer.length * 2;
+		}
 	}
 
 	void add(const document d) {

--- a/source/kaleidic/mongo_standalone.d
+++ b/source/kaleidic/mongo_standalone.d
@@ -887,8 +887,10 @@ struct SendBuffer {
 	private void size(size_t addition) {
 		if(buffer is null)
 			buffer = backing[];
-		if(position + addition > buffer.length)
-			buffer.length = buffer.length * 2;
+		if(position + addition > buffer.length) {
+                        buffer.length = buffer.length * 2;
+                        size(addition);
+                }
 	}
 
 	void add(const document d) {
@@ -995,6 +997,23 @@ struct SendBuffer {
 		buffer[2] = (sz >> 16) & 0xff;
 		buffer[3] = (sz >> 24) & 0xff;
 	}
+}
+
+unittest {
+        // A test for correct buffer allocation
+        import std.algorithm;
+        import std.range;
+        import std.conv;
+
+        // a large BSON array
+        auto anArray = iota(100000)
+                .enumerate()
+                .map!(tup => bson_value(tup.index.to!string, tup.value))
+                .array();
+
+        auto doc = document([bson_value("array", anArray)]);
+        SendBuffer buf;
+        buf.add(doc);
 }
 
 struct MsgHeader {

--- a/source/kaleidic/mongo_standalone.d
+++ b/source/kaleidic/mongo_standalone.d
@@ -999,20 +999,20 @@ struct SendBuffer {
 }
 
 unittest {
-        // A test for correct buffer allocation
-        import std.algorithm;
-        import std.range;
-        import std.conv;
+	// A test for correct buffer allocation
+	import std.algorithm;
+	import std.range;
+	import std.conv;
 
-        // a large BSON array
-        auto anArray = iota(100000)
-                .enumerate()
-                .map!(tup => bson_value(tup.index.to!string, tup.value))
-                .array();
+	// a large BSON array
+	auto anArray = iota(100000)
+		.enumerate()
+		.map!(tup => bson_value(tup.index.to!string, tup.value))
+		.array();
 
-        auto doc = document([bson_value("array", anArray)]);
-        SendBuffer buf;
-        buf.add(doc);
+	auto doc = document([bson_value("array", anArray)]);
+	SendBuffer buf;
+	buf.add(doc);
 }
 
 struct MsgHeader {


### PR DESCRIPTION
If the amount data to be written to `Sendbuffer` is greater than the double size of the existing buffer, some of the data is written beyond the buffer boundary if boundary checks are disabled or causes a `RangeError` exception otherwise.

The PR ensures that the buffer is large enough.