### PR TITLE
Add batch retrieval of many files for GridFS

### DIFF
--- a/source/kaleidic/mongo_gridfs.d
+++ b/source/kaleidic/mongo_gridfs.d
@@ -11,16 +11,7 @@ import kaleidic.mongo_standalone;
 +/
 
 ubyte[] gridfsReadFile(MongoConnection mongo, const string gridfsBucketName, const ObjectId id) {
-    OP_REPLY reply =
-        mongo.query(gridfsBucketName ~ ".files", 0, 1, document([bson_value("_id", id)]));
-    if (reply.errorCode != 0) {
-        throw new Exception(reply.errorMessage);
-    }
-    if (reply.documents.length != 1) {
-        throw new Exception("Requested file not found.");
-    }
-
-    return gridfsReadFileById(mongo, gridfsBucketName, id);
+    return gridfsReadManyFiles(mongo, gridfsBucketName, [id])[id];
 }
 
 /++
@@ -32,46 +23,130 @@ ubyte[] gridfsReadFile(MongoConnection mongo, const string gridfsBucketName, con
 +/
 
 ubyte[] gridfsReadFile(MongoConnection mongo, const string gridfsBucketName, const string name) {
-    OP_REPLY reply =
-        mongo.query(gridfsBucketName ~ ".files", 0, 2, document([bson_value("filename", name)]));
-    if (reply.errorCode != 0) {
-        throw new Exception(reply.errorMessage);
-    }
-    if (reply.documents.length != 1) {
-        throw new Exception("error: failed to match single file: '" ~ name ~ "'");
-    }
-    ObjectId id = reply.documents[0]["_id"].get!ObjectId;
-
-    return gridfsReadFileById(mongo, gridfsBucketName, id);
+    return gridfsReadManyFiles(mongo, gridfsBucketName, [name])[name];
 }
 
-private ubyte[] gridfsReadFileById(MongoConnection mongo, const string gridfsBucketName,
-                                   const ObjectId id) {
-    import std.outbuffer;
+/++
+   IN:     mongo            - active connection to the MongoDB instance.
+           gridfsBucketName - full path to the GridFS parent of collections .files and .chunks.
+           ids              - array of file object IDs, i.e., their "_id" values.
+   RETURN: An associative array containing id -> entire file content mappings.
+   THROWS: File not found, or on corrupt properties.
++/
 
-    OutBuffer contents = new OutBuffer();
-    string collectionName = gridfsBucketName ~ ".chunks";
+ubyte[][ObjectId] gridfsReadManyFiles(MongoConnection mongo, const string gridfsBucketName, const ObjectId[] ids) {
+    import std.algorithm;
+    import std.array;
 
-    OP_REPLY reply = mongo.query(collectionName, 0, int.max,
-                                 document([bson_value("files_id", id)]));
+    if (ids.length > int.max)
+        throw new Exception("Number of requested objects exceeds int.max");
+
+    // {"$or": [{"_id": id1}, {"_id": id2}, ... {"_id": idN}]}
+    auto query = document([bson_value("$or", makeArray(ids, "_id"))]);
+
+    OP_REPLY reply = mongo.query(gridfsBucketName ~ ".files", 0, cast(int)ids.length, query);
     if (reply.errorCode != 0) {
         throw new Exception(reply.errorMessage);
     }
 
-    foreach (doc; reply.documents) {
-        contents.write(doc["data"].get!(const(ubyte[])));
+    if (reply.documents.length != ids.length) {
+        auto givenIds = ids.dup.sort();
+        auto existingIds = reply.documents.map!(doc => doc["_id"].get!ObjectId).array.sort();
+        auto missingIds = setDifference(givenIds, existingIds).map!(id => id.toString()).join(", ");
+        throw new Exception("Requested file(s) not found. Missing id: " ~ missingIds);
     }
 
-    // fetch remaining documents if any
-    while (reply.cursorID != 0) {
-        reply = mongo.getMore(collectionName, int.max, reply.cursorID);
+    return gridfsReadFilesById(mongo, gridfsBucketName, ids);
+}
+
+/++
+   IN:     mongo            - active connection to the MongoDB instance.
+           gridfsBucketName - full path to the GridFS parent of collections .files and .chunks.
+           names            - array of file names.
+   RETURN: An associative array containing file name -> entire file content mappings.
+   THROWS: File not found, or if more than 1 file match name, or on corrupt properties.
++/
+
+ubyte[][string] gridfsReadManyFiles(MongoConnection mongo, const string gridfsBucketName, const string[] names) {
+    import std.algorithm;
+    import std.array;
+    import std.typecons;
+
+    // {"$or": [{"filename": name1}, {"filename": name2}, ... {"filename": nameN}]}
+    auto query = document([bson_value("$or", makeArray(names, "filename"))]);
+
+    OP_REPLY reply = mongo.query(gridfsBucketName ~ ".files", 0, int.max, query);
+    if (reply.errorCode != 0) {
+        throw new Exception(reply.errorMessage);
+    }
+
+    if (reply.documents.length != names.length) {
+        auto givenNames = names.dup().sort();
+        auto existingNames = reply.documents.map!(doc => doc["filename"].get!string).array().sort();
+        auto missingNames = setDifference(givenNames, existingNames).join(", ");
+        throw new Exception("Requested file(s) not found. Missing file(s): " ~ missingNames);
+    }
+
+    string[ObjectId] mappings = reply.documents
+        .map!(doc => tuple(doc["_id"].get!ObjectId, doc["filename"].get!string))
+        .assocArray();
+
+    auto result = gridfsReadFilesById(mongo, gridfsBucketName, mappings.keys)
+        .byPair()
+        .map!(tup => tuple(mappings[tup[0]], tup[1]))
+        .assocArray();
+
+    return result;
+}
+
+private ubyte[][ObjectId] gridfsReadFilesById(MongoConnection mongo, const string gridfsBucketName,
+                                    const ObjectId[] ids) {
+    import std.outbuffer;
+    import std.algorithm;
+    import std.array;
+    import std.typecons;
+
+    // {"$or": [{"files_id": id1}, {"files_id": id2}, ... {"files_id": idN}]}
+    auto query = bson_value("$query", document([bson_value("$or", makeArray(ids, "files_id"))]));
+    // order results by files_id and chunk number
+    auto orderBy = bson_value("$orderby", document([bson_value("files_id", 1), bson_value("n", 1)]));
+    auto queryDoc = document([query, orderBy]);
+
+    string collectionName = gridfsBucketName ~ ".chunks";
+    OutBuffer[ObjectId] result;
+
+    auto handleReply = (OP_REPLY reply) {
         if (reply.errorCode != 0) {
             throw new Exception(reply.errorMessage);
         }
         foreach (doc; reply.documents) {
+            if (doc["$err"] != bson_value.init) {
+                throw new Exception(doc["$err"].get!string);
+            }
+            auto contents = result.require(doc["files_id"].get!ObjectId, new OutBuffer());
             contents.write(doc["data"].get!(const(ubyte[])));
         }
+    };
+
+    OP_REPLY reply = mongo.query(collectionName, 0, int.max, queryDoc);
+    handleReply(reply);
+
+    // fetch remaining documents if any
+    while (reply.cursorID != 0) {
+        reply = mongo.getMore(collectionName, int.max, reply.cursorID);
+        handleReply(reply);
     }
 
-    return contents.toBytes;
+    return result.byPair().map!(tup => tuple(tup[0], tup[1].toBytes())).assocArray();
+}
+
+private bson_value[] makeArray(T)(T[] xs, string key) {
+    import std.algorithm;
+    import std.range;
+    import std.conv;
+
+    return xs
+        .enumerate()
+        .map!(tup => bson_value(tup.index.to!string, document([bson_value(key, tup.value)])))
+        .array();
 }

--- a/source/kaleidic/mongo_standalone.d
+++ b/source/kaleidic/mongo_standalone.d
@@ -1215,6 +1215,11 @@ struct ObjectId {
 			s = s[2 .. $];
 		}
 	}
+
+	int opCmp(ObjectId id) {
+		import std.algorithm;
+		return cmp(cast(ubyte[])this.v, cast(ubyte[])id.v);
+	}
 }
 struct UtcTimestamp {
 	long v;

--- a/test/gridfs/Makefile
+++ b/test/gridfs/Makefile
@@ -1,3 +1,4 @@
 all :
 	dub build --root ../..
 	dmd -I../../source test_gridfs.d ../../libmongo-standalone.a
+	dmd -I../../source test_gridfs_many.d ../../libmongo-standalone.a

--- a/test/gridfs/test.sh
+++ b/test/gridfs/test.sh
@@ -11,6 +11,14 @@ fi
 dd if=/dev/urandom of=small.bin bs=1K count=1
 dd if=/dev/urandom of=large.bin bs=1M count=100
 
+cleanup() {
+    for file in `ls *.bin`; do
+	mongofiles --quiet -d test_files delete $file >/dev/null
+	rm -f $file
+    done
+}
+trap cleanup EXIT
+
 mongofiles --quiet -d test_files -r put small.bin
 mongofiles --quiet -d test_files -r put large.bin
 
@@ -34,11 +42,3 @@ if [[ -x ./test_gridfs_many ]] ; then
 else
     ls many*.bin | xargs rdmd -g -I../../source test_gridfs_many.d
 fi
-
-cleanup() {
-    for file in `ls *.bin`; do
-	mongofiles --quiet -d test_files delete $file >/dev/null
-	rm -f $file
-    done
-}
-trap cleanup EXIT

--- a/test/gridfs/test.sh
+++ b/test/gridfs/test.sh
@@ -7,19 +7,12 @@ if [[ ! -x "$(which rdmd)" && ! -x ./test_gridfs ]] ; then
   exit 1
 fi
 
+# test single retrieval for a large and a small file
 dd if=/dev/urandom of=small.bin bs=1K count=1
 dd if=/dev/urandom of=large.bin bs=1M count=100
 
-mongofiles -d test_files -r put small.bin
-mongofiles -d test_files -r put large.bin
-
-cleanup() {
-  mongofiles -d test_files delete small.bin
-  mongofiles -d test_files delete large.bin
-
-  rm -f small.bin large.bin
-}
-trap cleanup EXIT
+mongofiles --quiet -d test_files -r put small.bin
+mongofiles --quiet -d test_files -r put large.bin
 
 if [[ -x ./test_gridfs ]] ; then
   ./test_gridfs small.bin $(sha1sum small.bin | cut -d ' ' -f 1)
@@ -28,3 +21,24 @@ else
   rdmd -g -I../../source test_gridfs.d small.bin $(sha1sum small.bin | cut -d ' ' -f 1)
   rdmd -g -I../../source test_gridfs.d large.bin $(sha1sum large.bin | cut -d ' ' -f 1)
 fi
+
+# test retrieval of many small files
+dd if=/dev/urandom of=many.bin bs=1M count=100
+split -b 100000 --additional-suffix .bin many.bin many
+for file in `ls many*.bin`; do
+    mongofiles --quiet -d test_files -r put $file >/dev/null
+done
+
+if [[ -x ./test_gridfs_many ]] ; then
+    ls many*.bin | xargs ./test_gridfs_many
+else
+    ls many*.bin | xargs rdmd -g -I../../source test_gridfs_many.d
+fi
+
+cleanup() {
+    for file in `ls *.bin`; do
+	mongofiles --quiet -d test_files delete $file >/dev/null
+	rm -f $file
+    done
+}
+trap cleanup EXIT

--- a/test/gridfs/test_gridfs_many.d
+++ b/test/gridfs/test_gridfs_many.d
@@ -1,0 +1,36 @@
+import kaleidic.mongo_standalone;
+import kaleidic.mongo_gridfs;
+
+import std.stdio;
+import std.file;
+import std.digest.sha;
+
+int main(string[] args) {
+    char[40][string] files;
+    MongoConnection mongo = new MongoConnection("mongodb://localhost/?slaveOk=true");
+
+    foreach(fileName; args[1..$]) {
+        auto hashBytes = sha1Of(read(fileName));
+        auto hashStr = toHexString!(LetterCase.lower)(hashBytes);
+        files[fileName] = hashStr;
+    }
+
+    auto fetchedFiles = gridfsReadManyFiles(mongo, "test_files.fs", files.keys);
+    foreach(fileName, contents; fetchedFiles) {
+        auto hashBytes = sha1Of(contents);
+        auto hashStr = toHexString!(LetterCase.lower)(hashBytes);
+        if (hashStr != files[fileName]) {
+            writeln("FAILURE:");
+            writeln("  NAME: ", fileName);
+            writeln("  SIZE: ", contents.length);
+            writeln("  SHA1: ", hashStr);
+            writeln("  EXPECTED SHA1: ", files[fileName]);
+            writeln("");
+            return 1;
+        }
+    }
+
+    writeln("SUCCESS: ", fetchedFiles.length, " files were read correctly");
+
+    return 0;
+}


### PR DESCRIPTION
Fetching many small files in one query as opposed to one file at a time can speed the operation dramatically. 

The PR proposes new API `gridfsReadManyFiles` which takes an array or file names or object ids.

Testing against several hundred files each up to 1KB in size  demonstrated two orders of magnitude improvement on a relatively high-latency connection and 2x improvement when fetching files over `localhost`. 